### PR TITLE
Add Contest.InProgress, remove Contest.Users

### DIFF
--- a/activity-contest-server.go
+++ b/activity-contest-server.go
@@ -35,7 +35,7 @@ type ActivitySummary struct {
 	StandPercent    uint
 }
 
-// score computes the score of an ActivitySummary.
+// score computes the score from an ActivitySummary.
 func (as ActivitySummary) score() uint {
 	return as.MovePercent + as.ExercisePercent + as.StandPercent
 }

--- a/activity-contest-server.go
+++ b/activity-contest-server.go
@@ -11,7 +11,7 @@ type Contest struct {
 	gorm.Model
 	StartDate      time.Time
 	EndDate        time.Time
-	Users          []User
+	InProgress     bool
 	ContestEntries []ContestEntry
 }
 
@@ -58,7 +58,7 @@ func main() {
 	c := Contest{
 		StartDate:      time.Now(),
 		EndDate:        time.Now().Add(time.Hour * 24 * 7),
-		Users:          []User{u},
+		InProgress:     true,
 		ContestEntries: []ContestEntry{ce},
 	}
 	fmt.Printf(


### PR DESCRIPTION
Faster lookup for whether a contest is in progress if it's a DB column. Users field is redundant since the ContestEntries slice field contains a user field.